### PR TITLE
Fix trace store message to tool call association

### DIFF
--- a/src/eval/core/index.ts
+++ b/src/eval/core/index.ts
@@ -98,7 +98,7 @@ export async function evaluate(
         const { success, messages, toolCalls } =
           await runner.runWorkflowWithLLM(workflow.steps);
 
-        // Import results into trace store
+        // Import results into trace store (messages only; tool calls already recorded)
         for (const message of messages) {
           traceStore.addMessage({
             role: message.role as "user" | "assistant",

--- a/src/eval/evaluators/llm-judge.ts
+++ b/src/eval/evaluators/llm-judge.ts
@@ -24,14 +24,14 @@ function buildConversationDump(
     .map((msg: ConversationMessage) => {
       let content = `${msg.role.toUpperCase()}: ${msg.content}`;
 
-      // Prefer explicit toolCalls if provided, otherwise resolve via toolCallIds
-      const associatedToolCalls = Array.isArray(msg.toolCalls) && msg.toolCalls.length > 0
-        ? msg.toolCalls
-        : Array.isArray(msg.toolCallIds) && msg.toolCallIds.length > 0
-          ? msg.toolCallIds
-              .map((id) => toolCallsById.get(id))
-              .filter((x): x is NonNullable<typeof x> => Boolean(x))
-          : [];
+      // Merge explicit toolCalls (if present) with resolved toolCallIds
+      const explicitCalls = Array.isArray(msg.toolCalls) ? msg.toolCalls : [];
+      const resolvedCalls = Array.isArray(msg.toolCallIds)
+        ? msg.toolCallIds
+            .map((id) => toolCallsById.get(id))
+            .filter((x): x is NonNullable<typeof x> => Boolean(x))
+        : [];
+      const associatedToolCalls = [...resolvedCalls, ...explicitCalls];
 
       if (associatedToolCalls.length > 0) {
         content += "\nTOOL CALLS:";

--- a/src/types/trace.ts
+++ b/src/types/trace.ts
@@ -27,6 +27,9 @@ export interface ConversationMessage {
   role: "user" | "assistant";
   content: string;
   toolCalls?: ToolCall[];
+  // Optional references to tool calls recorded in TraceStore
+  // Prefer using ids to avoid duplicating ToolCall data and ensure consistency
+  toolCallIds?: string[];
   timestamp: Date;
 }
 

--- a/tests/unit/evaluators/llm-judge.test.ts
+++ b/tests/unit/evaluators/llm-judge.test.ts
@@ -49,18 +49,20 @@ describe("LLM Judge", () => {
       timestamp: new Date(),
     });
 
+    // Record the tool call in the store and associate via toolCallIds on the assistant message
+    const toolCallId = "call_123";
+    traceStore.addToolCall({
+      id: toolCallId,
+      name: "calculate",
+      arguments: { a: 2, b: 2, operation: "add" },
+      timestamp: new Date(),
+    });
+
     traceStore.addMessage({
       role: "assistant",
       content: "The answer is 4",
       timestamp: new Date(),
-      toolCalls: [
-        {
-          id: "call_123",
-          name: "calculate",
-          arguments: { a: 2, b: 2, operation: "add" },
-          timestamp: new Date(),
-        },
-      ],
+      toolCallIds: [toolCallId],
     });
 
     traceStore.addToolResult({


### PR DESCRIPTION
Link `ConversationMessage` to canonical `TraceStore` tool calls via `toolCallIds` to fix `LLMJudge` inaccuracies.

Previously, `ConversationMessage` contained duplicated or fabricated `toolCalls` while the actual tool call records resided in `TraceStore.toolCalls`. This led to `LLMJudge` not accurately reflecting the tool calls associated with assistant messages. This PR introduces `toolCallIds` to `ConversationMessage` to reference the canonical tool calls, ensuring consistency and accuracy for evaluators.

---
<a href="https://cursor.com/background-agent?bcId=bc-8bdf2968-1e5c-47d8-8065-5415430a9136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8bdf2968-1e5c-47d8-8065-5415430a9136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

