### PR TITLE
feat: configure your own model in the evaluate function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # mcpvals
 
+## 0.4.0
+
+### Minor Changes
+
+- feat: adding anthropic model configuration
+
 ## 0.3.1
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcpvals",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Evaluation library for Model Context Protocol servers",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/eval/core/index.ts
+++ b/src/eval/core/index.ts
@@ -37,6 +37,7 @@ export async function evaluate(
   const runner = new ServerRunner(config.server, traceStore, {
     timeout: config.timeout,
     debug: options.debug,
+    model: options.model,
   });
 
   // Results collection

--- a/src/eval/core/runner.ts
+++ b/src/eval/core/runner.ts
@@ -39,6 +39,7 @@ export class ServerRunner {
   private options: ServerRunnerOptions;
   private performanceMonitor: PerformanceMonitor;
   private resilienceManager: ResilienceManager;
+  private model: string;
   private sseConnectionState: "connecting" | "connected" | "disconnected" =
     "disconnected";
   private reconnectTimeout?: NodeJS.Timeout;
@@ -54,6 +55,7 @@ export class ServerRunner {
     this.serverConfig = serverConfig;
     this.traceStore = traceStore || new TraceStore(options.traceStoreOptions);
     this.options = options;
+    this.model = options.model || "claude-sonnet-4-5";
 
     // Initialize performance monitoring
     this.performanceMonitor = new PerformanceMonitor(
@@ -655,7 +657,7 @@ Focus on completing the tasks accurately and efficiently.`;
         const result = await this.resilienceManager.executeWithResilience(
           async () => {
             return await generateText({
-              model: anthropic("claude-3-5-sonnet-20241022"),
+              model: anthropic(this.model),
               system: systemPrompt,
               messages,
               tools: aiTools,

--- a/src/types/evaluation.ts
+++ b/src/types/evaluation.ts
@@ -8,6 +8,7 @@ export interface EvaluateOptions {
   llmJudge?: boolean;
   toolHealthOnly?: boolean;
   workflowsOnly?: boolean;
+  model?: string; // Anthropic model name, defaults to claude-sonnet-4-5
 }
 
 export interface EvaluationReport {

--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -17,6 +17,7 @@ export type MCPTransports =
 export interface ServerRunnerOptions {
   timeout?: number;
   debug?: boolean;
+  model?: string; // Anthropic model name
   performanceThresholds?: Partial<PerformanceThresholds>;
   traceStoreOptions?: TraceStoreOptions;
   retryOptions?: Partial<RetryOptions>;


### PR DESCRIPTION
# what

added custom anthropic model configuration to the evaluate function and changed default model to claude 4.5 sonnet 